### PR TITLE
Remove codebuild env MAESTRO_CLEAR_CACHE

### DIFF
--- a/codebuild/lib/codebuild-stack.ts
+++ b/codebuild/lib/codebuild-stack.ts
@@ -351,9 +351,6 @@ export class CodebuildStack extends Stack {
       "MAESTRO_BRANCH_OVERRIDE": {
         value: branch
       },
-      "MAESTRO_CLEAR_CACHE": {
-        value: false
-      },
       "MAESTRO_DEBUG": {
         value: false
       },


### PR DESCRIPTION
This variable is no longer used in Maestro.